### PR TITLE
Run the GitHub action for rendering documents on translation branches

### DIFF
--- a/.github/workflows/render-markdown.yml
+++ b/.github/workflows/render-markdown.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - 'translation/**'
+      - 'translations/**'
 jobs:
   render-separate-files:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Specifically on branches starting with `translation/` or `translations/`, as well as on the `main` branch.
And as proof that it works: [this action](https://github.com/wyrmworkspublishing/free5e/actions/runs/16420919888) ran on this branch (which _does_ start with `translations/`, just to test and demonstrate).