### PR TITLE
Add the fighter class

### DIFF
--- a/en-US/Players_Guide/03_Creating_a_Character/Ancestries/Ancestries/Dragonborn.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Ancestries/Ancestries/Dragonborn.md
@@ -25,7 +25,8 @@ Choose the type of damage dealt by your breath weapon from the following list: a
 
 Additionally, choose between a 30-foot line that is 5 feet wide or a 15-foot cone for the area that your breath weapon affects.
 Each creature in the breath’s area makes a Dexterity saving throw.
-If your breath weapon deals psychic damage, a Wisdom saving throw is made instead of Dexterity; if cold, necrotic, poison, radiant, or thunder, a Constitution saving throw. The DC is 8 + your Constitution modifier + your proficiency bonus.
+If your breath weapon deals psychic damage, a Wisdom saving throw is made instead of Dexterity; if cold, necrotic, poison, radiant, or thunder, a Constitution saving throw.
+The DC is 8 + your Constitution modifier + your proficiency bonus.
 
 A creature takes 2d6 damage on a failed saving throw, or half damage on a success.
 The damage increases to 3d6 at 4th level, 4d6 at 9th level, 5d6 at 14th level, and 6d6 at 19th level.

--- a/en-US/Players_Guide/03_Creating_a_Character/Ancestries/Ancestries/Human.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Ancestries/Ancestries/Human.md
@@ -22,5 +22,6 @@ Your base walking speed is 30 feet.
 Once between rests, when you make an ability check, attack roll, or saving throw, you can choose to add the result of a d4 to that roll.
 \
 **It Takes a Village.**
-You can use the Help action as a bonus action. Once per long rest when you Help an ally, in addition to granting advantage you may also choose for your ally to gain a d4 on that roll.
+You can use the Help action as a bonus action.
+Once per long rest when you Help an ally, in addition to granting advantage you may also choose for your ally to gain a d4 on that roll.
 You can be up to 15 feet away from the attack's target.

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Adept/Adept.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Adept/Adept.md
@@ -99,7 +99,8 @@ You gain the following benefits while you are unarmed or wielding only Adept wea
 - When you use the Attack action with an unarmed strike or an Adept weapon on your turn, you can make one unarmed strike as a bonus action.
   For example, if you take the Attack action and attack with a quarterstaff, you can also make an unarmed strike as a bonus action, assuming you haven’t already taken a bonus action this turn.
 
-Certain monasteries use specialized forms of the Adept weapons. For example, you might use a club that is two lengths of wood connected by a short chain (called a nunchaku) or a sickle with a shorter, straighter blade (called a kama).
+Certain monasteries use specialized forms of the Adept weapons.
+For example, you might use a club that is two lengths of wood connected by a short chain (called a nunchaku) or a sickle with a shorter, straighter blade (called a kama).
 Whatever name you use for an Adept weapon, you can use the game statistics provided for the weapon.
 
 ###### Focus (2nd Level) {#Adept_focus}
@@ -108,7 +109,8 @@ Your training allows you to harness the mystic energy of focus points.
 Your access to this energy is represented by a number of focus points.
 Your Adept level determines the number of points you have, as shown in the Focus Points column of the [Adept table](#Adept_the_adept_table).
 
-You can spend these points to fuel various focus features. You start knowing three such features: _Flurry of Blows_, Patient Defense_, and _Step of the Wind_.
+You can spend these points to fuel various focus features.
+You start knowing three such features: _Flurry of Blows_, Patient Defense_, and _Step of the Wind_.
 
 - **Flurry of Blows (1 focus point).**
   Immediately after you take the Attack action on your turn, make two unarmed strikes as a bonus action.

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Adept/Adept.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Adept/Adept.md
@@ -117,7 +117,7 @@ You start knowing three such features: _Flurry of Blows_, Patient Defense_, and 
 - **Patient Defense (1 focus point).**
   Take the Dodge action as a bonus action on your turn.
 - **Step of the Wind (1 focus point).**
-  Take the Disengage or Dash action as a bonus action on your turn, and your jump distance is doubled for the turn.
+  Take the Disengage or Dash action as a bonus action on your turn, and your [jump distance](#Exploration_Movement_jumping) is doubled for the turn.
 
 You learn more focus features as you gain levels in this class.
 

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Adept/Disciple_of_the_Outcast.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Adept/Disciple_of_the_Outcast.md
@@ -1,6 +1,9 @@
 ##### Discipline of the Outcast
 
-An Outcast is an Adept that has lost their Way. Trained in the basics of the style, they have abandoned the rigorous discipline and philosophy of their tradition, and are usually now enrolled only in the school of hard knocks. Having been trained in the fundamentals of the art of focus points, these Adepts choose as often as not to apply that art to tavern brawls and street fights. Much to the horror of many more formal Adepts, their rough and tumble lifestyle tends to be a solid source of further training.
+An Outcast is an Adept that has lost their Way.
+Trained in the basics of the style, they have abandoned the rigorous discipline and philosophy of their tradition, and are usually now enrolled only in the school of hard knocks.
+Having been trained in the fundamentals of the art of focus points, these Adepts choose as often as not to apply that art to tavern brawls and street fights.
+Much to the horror of many more formal Adepts, their rough and tumble lifestyle tends to be a solid source of further training.
 
 > **How Outcasts Come to Be**
 > \
@@ -32,7 +35,8 @@ You gain the following additional Pragmatic Techniques you can spend focus on.
 - **Kick 'em While They’re Down (1 focus point).**
   When you hit a target that is prone, restrained, or incapacitated, you can expend a focus point to deal additional damage equal to two rolls of your Martial Arts die.
 - **Unexpected Technique (1 focus point).**
-  When you make a grapple check, you can expend a focus point to add your Martial Arts die to the roll. You can do this after the contested roll, and it can potentially turn a failure into a success.
+  When you make a grapple check, you can expend a focus point to add your Martial Arts die to the roll.
+  You can do this after the contested roll, and it can potentially turn a failure into a success.
   On success, the target takes damage equal to the amount rolled on the added die.
 
 ###### Soak It Up (6th Level)

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Bard/College_of_Fools.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Bard/College_of_Fools.md
@@ -4,8 +4,8 @@ The College of Fools is a motley lot, varying from bumbling beggars to the eyeso
 One can tell at a glance they are not to be taken seriously, but beneath the facade there is...
 well, usually a fool, but also a sharp mind, quick hands, and an uncanny understanding of how to manipulate any situation.
 
-The College of Fools is tolerated much like an assassin’s guild might be:
-a useful menace to society. Hiding in the brilliant outfits in plain sight more surely than darkened leather could hide them in the shadows, they gather information, poke and prod their enemies, and—just occasionally—toss a knife in the air and forget to catch it before it hits someone.
+The College of Fools is tolerated much like an assassin’s guild might be: a useful menace to society.
+Hiding in the brilliant outfits in plain sight more surely than darkened leather could hide them in the shadows, they gather information, poke and prod their enemies, and—just occasionally—toss a knife in the air and forget to catch it before it hits someone.
 
 ###### Jester’s Juggling (3rd Level)
 

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Cleric/Cleric.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Cleric/Cleric.md
@@ -74,7 +74,8 @@ As a conduit for divine power, you can cast Cleric spells.
 
 **Cantrips**
 \
-At 1st level, you know three cantrips of your choice from the Cleric spell list. You learn additional Cleric cantrips of your choice at higher levels, as shown in the Cantrips Known column of the [Cleric table](#Cleric_the_cleric_table).
+At 1st level, you know three cantrips of your choice from the Cleric spell list.
+You learn additional Cleric cantrips of your choice at higher levels, as shown in the Cantrips Known column of the [Cleric table](#Cleric_the_cleric_table).
 \
 **Preparing and Casting Spells**
 \
@@ -151,7 +152,8 @@ Each undead that can pinpoint you within 30 feet of you must make a Wisdom savin
 If the creature fails its saving throw, it is turned for 1 minute or until it takes any damage.
 
 A turned creature must spend its turns trying to move as far away from you as it can, and it can’t willingly move to a space within 30 feet of you.
-It also can’t take reactions. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving.
+It also can’t take reactions.
+For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving.
 If there’s nowhere to move, the creature can use the Dodge action.
 
 ###### Ability Score Improvement (4th & 8th & 12th & 16th & 19th Level) {#Cleric_asi}

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Dreadnought/Dreadnought.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Dreadnought/Dreadnought.md
@@ -152,7 +152,9 @@ If your total for a Strength check is less than your Strength score, you can use
 
 ###### Primal Champion (20th Level) {#Dreadnought_primal_champion}
 
-You embody the power of the wilds. Your Strength and Constitution scores increase by 4. Your maximum for those scores is now 24.
+You embody the power of the wilds.
+Your Strength and Constitution scores increase by 4.
+Your maximum for those scores is now 24.
 
 ##### Dreadnought Paths
 

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Dreadnought/Path_of_the_Dragon.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Dreadnought/Path_of_the_Dragon.md
@@ -11,7 +11,8 @@ Some, particularly those rare individuals that channel metallic colors, may be e
 
 When you enter a rage, you can choose to make your Rage bonus damage deal elemental damage matching your draconic type (shown on the table below).
 
-Additionally, when you enter a rage you can take on aspects of a draconic entity, growing vicious natural weapons as claws grow from your hands, fangs sprout from your maw, and a vicious lashing tail grows from your back. Your claws deal 1d4 slashing damage.
+Additionally, when you enter a rage you can take on aspects of a draconic entity, growing vicious natural weapons as claws grow from your hands, fangs sprout from your maw, and a vicious lashing tail grows from your back.
+Your claws deal 1d4 slashing damage.
 Your fangs deal 1d8 piercing damage, and your lashing tail deals 1d6 bludgeoning damage and has the reach property.
 
 Whenever you attack with one of these natural weapons using the Attack action on your turn, if you are not carrying any weapon or shield, you can make a single unarmed strike with your claws as a bonus action.
@@ -48,8 +49,12 @@ The natural weapons you gain while raging now count as magical for the purpose o
 
 ###### Dragonhide (10th Level)
 
-The marks of your Draconic path now remain outside of your rage, manifesting as heavy scales that grant you resistance to bludgeoning, piercing, and slashing damage from nonmagical sources even when you are not raging. Additionally, you gain resistance to your dragon color’s elemental type even when you are not raging.
+The marks of your Draconic path now remain outside of your rage, manifesting as heavy scales that grant you resistance to bludgeoning, piercing, and slashing damage from nonmagical sources even when you are not raging.
+Additionally, you gain resistance to your dragon color’s elemental type even when you are not raging.
 
 ###### Tyrant of the Skies
-When you enter a rage, you can sprout massive dragon wings from your back. If you are not wearing heavy armor, you gain a flying speed equal to your movement speed.
-If you choose to manifest natural weapons and wings when you enter a rage, you can choose to entirely take on a draconic form while raging, becoming Large sized. When you take on a full draconic form, you choose whether your equipment falls to the ground in your space, merges into your new form, or is worn by it.
+
+When you enter a rage, you can sprout massive dragon wings from your back.
+If you are not wearing heavy armor, you gain a flying speed equal to your movement speed.
+If you choose to manifest natural weapons and wings when you enter a rage, you can choose to entirely take on a draconic form while raging, becoming Large sized.
+When you take on a full draconic form, you choose whether your equipment falls to the ground in your space, merges into your new form, or is worn by it.

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Fighter/Brawler.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Fighter/Brawler.md
@@ -1,0 +1,42 @@
+##### Brawler
+
+A brawler is a Fighter that takes a holistic approach to beating things down.
+They are not the specialized martial artists of Adepts, but can throw a punch... or a chair.
+They specialize in being resourceful and, more importantly, strong.
+Ranging from brutish thugs and drunks to witty chaps who had to learn to wag their fists as fast as their tongue to keep their head on their shoulders.
+
+A brawler is always armed and dangerous, and isn’t above using a weapon if it’s the handiest way to bash something; they just don’t view themselves as limited to traditional options.
+
+###### Weapon is a State of Mind (3rd Level)
+
+You gain a remarkable ability to turn anything into a weapon—fists, improvised weapons, goblins, etc.
+You can add your proficiency bonus to attacks made with improvised weapons, and all attacks you make with them deal `1d8` damage bludgeoning, piercing, or slashing damage (depending on their nature) if their damage die would be smaller.
+You can use creatures you are grappling as improvised weapons with the [Thrown 5/10](#Weapon_Properties_weapon_properties) property.
+If they are one or more sizes smaller than you, they gain the [Light](#Weapon_Properties_weapon_properties) property.
+When you make an attack using a creature or object as a weapon, you can choose to deal damage equal to your Strength modifier to the creature or object you are using as a weapon.
+
+###### Flexible Style (3rd Level)
+
+You can apply the benefit of any [Fighting Style](#Fighter_fighting_style) you know to any weapon attack (including unarmed strikes and improvised weapons).
+If you have multiple Fighting Styles you may pick one which benefits the attack.
+Additionally, at the end of a long rest, you can change your [Fighting Style](#Fighter_fighting_styles_list) selection.
+
+###### Endurance (7th Level)
+
+You gain a remarkable ability to shrug off blows.
+When you use your [Second Wind](#Fighter_second_wind) feature, you gain resistance to bludgeoning, piercing, and slashing damage until the start of your next turn.
+
+###### Additional Fighting Style (10th Level)
+
+You can choose a second [option](#Fighter_fighting_styles_list) from the [Fighting Style](#Fighter_fighting_style) class feature.
+
+###### Brutal Blows (15th Level)
+
+The minimum damage die of your attacks becomes `1d10` (up from `1d8`).
+Additionally, when you choose to deal damage to a creature or object you are using as a weapon, it takes damage equal to the damage dealt by the attack.
+
+###### Legendary Feat (18th Level)
+
+You can perform legendary feats that defy all common sense.
+Before you make an attack roll, saving throw, or Strength, Dexterity, or Constitution ability check, you can make it a legendary feat, adding your Fighter level to the roll.
+Once you do so, you cannot do so again until you complete a short or long rest.

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Fighter/Champion.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Fighter/Champion.md
@@ -1,0 +1,28 @@
+##### Champion
+
+The archetypal Champion focuses on the development of raw physical power honed to deadly perfection.
+Those who model themselves on this archetype combine rigorous training with physical excellence to deal devastating blows.
+
+###### Improved Critical (3rd Level)
+
+Your weapon attacks score a critical hit on a roll of 19 or 20.
+
+###### Remarkable Athlete (7th Level)
+
+You can add half your proficiency bonus (round up) to any Strength, Dexterity, or Constitution check you make that doesn’t already use your proficiency bonus.
+
+In addition, when you make a [running long jump](#Exploration_Movement_jumping), the distance you can cover increases by a number of feet equal to your Strength modifier.
+
+###### Additional Fighting Style (10th Level)
+
+You can choose a second [option](#Fighter_fighting_styles_list) from the [Fighting Style](#Fighter_fighting_style) class feature.
+
+###### Superior Critical (15th Level)
+
+Your weapon attacks score a critical hit on a roll of 18–20.
+
+###### Survivor (18th Level)
+
+You attain the pinnacle of resilience in battle.
+At the start of each of your turns, you regain hit points equal to `5 + your Constitution modifier` if you have no more than half of your hit points left.
+You don’t gain this benefit if you have 0 hit points.

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Fighter/Fighter.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Fighter/Fighter.md
@@ -1,4 +1,134 @@
 #### Fighter
 
-> **Warning:**
-> This class has not yet been transferred from the Google Doc.
+Fighters refine combat into an art form, excelling with weapons, strategy, and sheer determination.
+
+##### Class Features
+
+As a Fighter, you gain the following class features.
+
+###### Hit Points
+
+**Hit Dice:**
+`1d10` per Fighter level
+\
+**Hit Points at 1st Level:**
+`10 + your Constitution modifier`
+\
+**Hit Points at Higher Levels:**
+`1d10 (or 6) + your Constitution modifier per Fighter level after 1st`
+
+###### Proficiencies
+
+**Armor:**
+All armor, shields
+\
+**Weapons:**
+Simple weapons, martial weapons
+\
+**Tools:**
+None
+\
+**Saving Throws:**
+Strength, Constitution
+\
+**Skills:**
+Choose two skills from Acrobatics, Animal, Handling, Athletics, History, Insight, Intimidation, Perception, and Survival
+
+###### Equipment
+You start with the following equipment, in addition to the equipment granted by your background:
+
+- (a) chain mail or (b) leather armor, longbow, and 20 arrows
+- (a) a martial weapon and a shield or (b) two martial weapons
+- (a) a light crossbow and 20 bolts or (b) two handaxes
+- (a) a dungeoneer’s pack or (b) an explorer’s pack
+
+###### The Fighter (table)
+
+| Level | Proficiency Bonus | Features                                                                                           |
+|:------|:------------------|:---------------------------------------------------------------------------------------------------|
+|  1st  |        +2         | [Fighting Style](#Fighter_fighting_style), [Second Wind](#Fighter_second_wind)                     |
+|  2nd  |        +2         | [Action Surge](#Fighter_action_surge) (one use)                                                    |
+|  3rd  |        +2         | [Martial Archetype](#Fighter_martial_archetype)                                                    |
+|  4th  |        +2         | [Ability Score Improvement](#Fighter_asi)                                                          |
+|  5th  |        +3         | [Extra Attack](#Fighter_extra_attack)                                                              |
+|  6th  |        +3         | [Ability Score Improvement](#Fighter_asi)                                                          |
+|  7th  |        +3         | Martial Archetype Feature                                                                          |
+|  8th  |        +3         | [Ability Score Improvement](#Fighter_asi)                                                          |
+|  9th  |        +4         | [Indomitable](#Fighter_indomitable) (one use)                                                      |
+| 10th  |        +4         | Martial Archetype Feature                                                                          |
+| 11th  |        +4         | [Extra Attack](#Fighter_extra_attack) (2)                                                          |
+| 12th  |        +4         | [Ability Score Improvement](#Fighter_asi)                                                          |
+| 13th  |        +5         | [Indomitable](#Fighter_indomitable) (two uses)                                                     |
+| 14th  |        +5         | [Ability Score Improvement](#Fighter_asi)                                                          |
+| 15th  |        +5         | Martial Archetype Feature                                                                          |
+| 16th  |        +5         | [Ability Score Improvement](#Fighter_asi)                                                          |
+| 17th  |        +6         | [Action Surge](#Fighter_action_surge) (two uses), [Indomitable](#Fighter_indomitable) (three uses) |
+| 18th  |        +6         | Martial Archetype Feature                                                                          |
+| 19th  |        +6         | [Ability Score Improvement](#Fighter_asi)                                                          |
+| 20th  |        +6         | [Extra Attack](#Fighter_extra_attack) (3)                                                          |
+
+###### Fighting Style (1st Level) {#Fighter_fighting_style}
+
+You adopt a particular style of fighting as your specialty.
+Choose one of the options listed [at the end of the class description](#Fighter_fighting_styles_list).
+You can’t take a Fighting Style option more than once, even if you later get to choose again.
+
+###### Second Wind (2nd Level) {#Fighter_second_wind}
+
+You have a limited well of stamina that you can draw on to protect yourself from harm.
+On your turn, you can use a bonus action to regain hit points equal to `1d10 + your Fighter level`.
+Once you use this feature, you must finish a short or long rest before you can use it again.
+
+###### Action Surge (2nd & 17th Level) {#Fighter_action_surge}
+
+You can push yourself beyond your normal limits for a moment.
+On your turn, you can take one additional action on top of your regular action and a possible bonus action.
+
+Once you use this feature, you must finish a short or long rest before you can use it again.
+Starting at 17th level, you can use it twice before a rest, but only once on the same turn.
+
+###### Martial Archetype (3rd & 7th & 10th & 15th & 18th Level) {#Fighter_martial_archetype}
+
+You choose an [archetype](#Fighter_martial_archetypes_list) that you strive to emulate in your combat styles and techniques.
+The archetype you choose grants you features at 3rd level and again at 7th, 10th, 15th, and 18th level.
+
+###### Ability Score Improvement (4th & 6th & 8th & 12th & 14th & 16th & 19th Level) {#Fighter_asi}
+
+When you reach 4th level, and again at 6th, 8th, 12th, 14th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1.
+As normal, you can’t increase an ability score above 20 using this feature.
+
+###### Extra Attack (5th & 11th & 20th Level) {#Fighter_extra_attack}
+
+Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn.
+
+The number of attacks increases to three when you reach 11th level in this class and to four when you reach 20th level in this class.
+
+###### Indomitable (9th & 13th & 17th Level)
+
+Beginning at 9th level, you can reroll a saving throw that you fail.
+If you do so, you must use the new roll, and you can’t use this feature again until you finish a long rest.
+
+You can use this feature twice between long rests starting at 13th level and three times between long rests starting at 17th level.
+
+##### Fighting Styles {#Fighter_fighting_styles_list}
+
+[**Archery**](../_Fighting_Styles/Archery.md)
+
+[**Defense**](../_Fighting_Styles/Defense.md)
+
+[**Dueling**](../_Fighting_Styles/Dueling.md)
+
+[**Great Weapon Fighting**](../_Fighting_Styles/Great_Weapon_Fighting.md)
+
+[**Protection**](../_Fighting_Styles/Protection.md)
+
+[**Two-Weapon Fighting**](../_Fighting_Styles/Two-Weapon_Fighting.md)
+
+##### Martial Archetypes {#Fighter_martial_archetypes_list}
+
+Different Fighters choose different approaches to perfecting their fighting prowess.
+The martial archetype you choose to emulate reflects your approach.
+
+[**Brawler**](./Brawler.md)
+
+[**Champion**](./Champion.md)

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Rogue/Rogue.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Rogue/Rogue.md
@@ -74,7 +74,8 @@ At 6th level, you can choose two more of your proficiencies (in skills or with t
 ###### Sneak Attack (1st Level) {#Rogue_sneak_attack}
 
 You know how to strike subtly and exploit a foe’s distraction.
-Once per turn, you can deal an extra 1d6 damage to one creature you hit with an attack if you have advantage on the attack roll. The attack must use a finesse or a ranged weapon.
+Once per turn, you can deal an extra 1d6 damage to one creature you hit with an attack if you have advantage on the attack roll.
+The attack must use a finesse or a ranged weapon.
 
 You don’t need advantage on the attack roll if another enemy of the target is within 5 feet of it, that enemy isn’t incapacitated, and you don’t have disadvantage on the attack roll.
 

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Vanguard/Oath_of_Devotion.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Vanguard/Oath_of_Devotion.md
@@ -48,7 +48,8 @@ You gain the following two Channel Divinity options.
 
 **Sacred Weapon.**
 As an action, you can imbue one weapon that you are holding with positive energy, using your Channel Divinity.
-For 1 minute, you add your Charisma modifier to attack rolls made with that weapon (with a minimum bonus of +1). The weapon also emits bright light in a 20-foot radius and dim light 20 feet beyond that.
+For 1 minute, you add your Charisma modifier to attack rolls made with that weapon (with a minimum bonus of +1).
+The weapon also emits bright light in a 20-foot radius and dim light 20 feet beyond that.
 If the weapon is not already magical, it becomes magical for the duration.
 
 You can end this effect on your turn as part of any other action.

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Vanguard/Vanguard.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Vanguard/Vanguard.md
@@ -106,6 +106,7 @@ You can cure multiple diseases and neutralize multiple poisons with a single use
 This feature has no effect on undead and constructs.
 
 ###### Fighting Style (2nd Level) {#Vanguard_fighting_style}
+
 You adopt a style of fighting as your specialty.
 Choose one of the options listed [at the end of the class description](#Vanguard_fighting_styles_list).
 You can’t take a Fighting Style option more than once, even if you later get to choose again.
@@ -163,13 +164,15 @@ The divine magic flowing through you makes you immune to disease.
 
 You swear the oath that binds you as a Vanguard forever.
 Up to this time you have been in a preparatory stage, committed to the path but not yet sworn to it.
-Your choice grants you features at 3rd level and again at 7th, 15th, and 20th level. Those features include oath spells and the Channel Divinity feature.
+Your choice grants you features at 3rd level and again at 7th, 15th, and 20th level.
+Those features include oath spells and the Channel Divinity feature.
 
 **Oath Spells**
 \
 Each oath has a list of associated spells.
 You gain access to these spells at the levels specified in the oath description.
-Once you gain access to an oath spell, you always have it prepared. Oath spells don’t count against the number of spells you can prepare each day.
+Once you gain access to an oath spell, you always have it prepared.
+Oath spells don’t count against the number of spells you can prepare each day.
 
 If you gain an oath spell that doesn’t appear on the Vanguard spell list, the spell is nonetheless a Vanguard spell for you.
 
@@ -192,7 +195,9 @@ At levels 4, 8, 12, 16, and 19, you can increase one ability score by 2 or two a
 You can attack twice, instead of once, whenever you take the Attack action on your turn.
 
 ###### Aura of Protection (6th & 18th Level) {#Vanguard_aura_of_protection}
-Starting at 6th level, whenever you or a friendly creature within 10 feet of you must make a saving throw, the creature gains a bonus to the saving throw equal to your Charisma modifier (with a minimum bonus of +1). You must be conscious to grant this bonus.
+
+Starting at 6th level, whenever you or a friendly creature within 10 feet of you must make a saving throw, the creature gains a bonus to the saving throw equal to your Charisma modifier (with a minimum bonus of +1).
+You must be conscious to grant this bonus.
 At 18th level, the range of this aura increases to 30 feet.
 
 ###### Aura of Courage (10th & 18th Level) {#Vanguard_aura_of_courage}

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Warlock/The_Overseer.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Warlock/The_Overseer.md
@@ -41,7 +41,8 @@ You can do this a number of times equal to your Proficiency bonus, regaining all
 ###### Lingering Gaze (6th Level) {#The_Overseer_lingering_gaze}
 
 When you invoke your [Overseer’s Gaze](#The_Overseer_overseers_gaze), the spectral eye lasts for 1 minute before fading away, and you use your bonus action on each of turns to cause it to fire again, rolling on the table anew.
-Once during the duration of each eye, you can pick the effect it fires instead of rolling. The spectral eye moves with you and is always in your space.
+Once during the duration of each eye, you can pick the effect it fires instead of rolling.
+The spectral eye moves with you and is always in your space.
 
 While you have the spectral eye with you, have advantage on [Wisdom (Perception)](#Using_Wisdom_wisdom_checks) checks and can perform the [Search](#Combat_Actions_search) action as a bonus action (instead of firing an eye ray).
 

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Warlock/Warlock.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Warlock/Warlock.md
@@ -161,7 +161,8 @@ The beings that serve as patrons for Warlocks are mighty inhabitants of other pl
 Various patrons give their Warlocks access to different powers and invocations, and expect significant favors in return.
 
 Some patrons collect Warlocks, doling out mystic knowledge relatively freely or boasting of their ability to bind mortals to their will.
-Other patrons bestow their power only grudgingly, and might make a pact with only one Warlock. Warlocks who serve the same patron might view each other as allies, siblings, or rivals.
+Other patrons bestow their power only grudgingly, and might make a pact with only one Warlock.
+Warlocks who serve the same patron might view each other as allies, siblings, or rivals.
 
 [**The Fiend**](./The_Fiend.md)
 

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Wodewose/Wodewose.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Wodewose/Wodewose.md
@@ -95,7 +95,8 @@ Drawing on the divine essence of nature itself, you can cast spells to shape tha
 
 **Cantrips**
 \
-At 1st level, you know two cantrips of your choice from the Wodewose spell list. You learn additional Wodewose cantrips of your choice at higher levels, as shown in the Cantrips Known column of the Wodewose table.
+At 1st level, you know two cantrips of your choice from the Wodewose spell list.
+You learn additional Wodewose cantrips of your choice at higher levels, as shown in the Cantrips Known column of the Wodewose table.
 
 **Preparing and Casting Spells**
 \

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/Wodewose/Wodewose.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/Wodewose/Wodewose.md
@@ -96,7 +96,7 @@ Drawing on the divine essence of nature itself, you can cast spells to shape tha
 **Cantrips**
 \
 At 1st level, you know two cantrips of your choice from the Wodewose spell list.
-You learn additional Wodewose cantrips of your choice at higher levels, as shown in the Cantrips Known column of the Wodewose table.
+You learn additional Wodewose cantrips of your choice at higher levels, as shown in the Cantrips Known column of the [Wodewose table](#Wodewose_the_wodewose_table).
 
 **Preparing and Casting Spells**
 \

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/_Fighting_Styles/Archery.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/_Fighting_Styles/Archery.md
@@ -1,0 +1,3 @@
+###### Archery
+
+You gain a +2 bonus to attack rolls you make with ranged weapons.

--- a/en-US/Players_Guide/03_Creating_a_Character/Classes/_Fighting_Styles/Two-Weapon_Fighting.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Classes/_Fighting_Styles/Two-Weapon_Fighting.md
@@ -1,0 +1,3 @@
+###### Two-Weapon Fighting
+
+When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack.

--- a/en-US/Players_Guide/03_Creating_a_Character/Cultures/Cultures/Dragonbound.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Cultures/Cultures/Dragonbound.md
@@ -8,7 +8,8 @@ Its members consider themselves stewards of draconic wisdom and tradition.
 You gain expertise on Charisma checks made to influence dragon creatures.
 \
 **Dragonbound Teachings.**
-You know one cantrip of your choice from the [Cleric](#Cleric_Spells_cleric_spells) or [Wizard spell lists](#Wizard_Spells_wizard_spells). Your spellcasting ability for this cantrip is Intelligence or Wisdom (whichever is highest).
+You know one cantrip of your choice from the [Cleric](#Cleric_Spells_cleric_spells) or [Wizard spell lists](#Wizard_Spells_wizard_spells).
+Your spellcasting ability for this cantrip is Intelligence or Wisdom (whichever is highest).
 \
 **Progenitor’s Boon.**
 Choose one of the following:

--- a/en-US/Players_Guide/03_Creating_a_Character/Equipment/Armor.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Equipment/Armor.md
@@ -1,6 +1,7 @@
 #### Armor
 Fantasy gaming worlds have diverse cultures with varying technology levels, offering adventurers a wide range of armor types, from leather to chain mail and costly plate armor.
-The Armor table categorizes these common armor types into light, medium, and heavy armor, along with their cost, weight, and other properties. Many warriors also use shields.
+The Armor table categorizes these common armor types into light, medium, and heavy armor, along with their cost, weight, and other properties.
+Many warriors also use shields.
 \
 **Armor Proficiency.**
 Anyone can put on a suit of armor or strap a shield to an arm.

--- a/en-US/Players_Guide/03_Creating_a_Character/Equipment/Tools.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Equipment/Tools.md
@@ -83,7 +83,8 @@ Also, proficiency with this kit is required to create antitoxin and potions of h
 **Musical Instrument.**
 Several of the most common types of musical instruments are shown on the table as examples.
 If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.
-A Bard can use a musical instrument as a spellcasting focus. Each type of musical instrument requires a separate proficiency.
+A Bard can use a musical instrument as a spellcasting focus.
+Each type of musical instrument requires a separate proficiency.
 \
 **Navigator’s Tools.**
 This set of instruments is used for navigation at sea.

--- a/en-US/Players_Guide/03_Creating_a_Character/Equipment/Trade_Goods.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Equipment/Trade_Goods.md
@@ -5,7 +5,8 @@ Most wealth isn’t in coins but in livestock, grain, land, tax rights, or resou
 Guilds, nobles, and royalty regulate trade.
 Chartered companies get rights to trade routes, ports, or goods.
 Guilds set prices and control who offers goods.
-Merchants often trade without currency. The Trade Goods table shows common trade goods’ values.
+Merchants often trade without currency.
+The Trade Goods table shows common trade goods’ values.
 
 ##### Trade Goods (table)
 

--- a/en-US/Players_Guide/03_Creating_a_Character/Equipment/Weapon_Properties.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Equipment/Weapon_Properties.md
@@ -4,7 +4,8 @@ Many weapons have special properties related to their use, as shown in the Weapo
 \
 **Ammunition.**
 You can use a ranged weapon with ammunition only if you have ammunition.
-Each attack uses one piece of ammunition. Drawing ammunition from a container is part of the attack.
+Each attack uses one piece of ammunition.
+Drawing ammunition from a container is part of the attack.
 You can recover half your expended ammunition by searching the battlefield at the end of the battle.
 
 If you use a ranged weapon with ammunition for a melee attack, treat it as an improvised weapon.
@@ -26,7 +27,8 @@ Because of the time required to load this weapon, you can fire only one piece of
 \
 **Range.**
 A weapon that can be used to make a ranged attack has a range in parentheses after the ammunition or thrown property.
-The range lists two numbers. The first is the weapon’s normal range in feet, and the second indicates the weapon’s long range.
+The range lists two numbers.
+The first is the weapon’s normal range in feet, and the second indicates the weapon’s long range.
 When attacking a target beyond normal range, you have disadvantage on the attack roll.
 You can’t attack a target beyond the weapon’s long range.
 \

--- a/en-US/Players_Guide/03_Creating_a_Character/Feats/Feats/Athletic.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Feats/Feats/Athletic.md
@@ -3,4 +3,4 @@
 - Your Strength or Dexterity score increases by 1, to a maximum of 20.
 - Standing up from being prone uses only 5 feet of your movement (instead of half).
 - Your speed is not halved from climbing.
-- You need only 5 feet (instead of 10 feet) to make a running jump.
+- You need only 5 feet (instead of 10 feet) to make a [running jump](#Exploration_Movement_jumping).

--- a/en-US/Players_Guide/03_Creating_a_Character/Feats/Feats/Deadeye.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Feats/Feats/Deadeye.md
@@ -7,4 +7,5 @@
 - When making a ranged weapon attack you make before the start of your turn, you can completely ignore a target’s cover.
   Only targets that have total cover from being entirely enclosed by an object or effect (such as inside of a chamber with no openings to shoot through or a sphere from Wall of Force) have cover against this attack, and you do not have disadvantage from attacking a target you cannot see.
 - Before you make an attack with a ranged weapon you are proficient with, you can choose to take a penalty on the attack roll equal to your proficiency bonus.
-  If the attack hits, you deal extra damage equal to double your proficiency bonus. This extra damage does not double on a critical hit.
+  If the attack hits, you deal extra damage equal to double your proficiency bonus.
+  This extra damage does not double on a critical hit.

--- a/en-US/Players_Guide/03_Creating_a_Character/Feats/Feats/Natural_Warrior.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Feats/Feats/Natural_Warrior.md
@@ -2,7 +2,7 @@
 
 - Your Speed increases by 5 feet.
 - When making an Acrobatics or Athletics check during combat, you can choose to use your Strength or Dexterity modifier for either skill.
-- Move 15 feet in a straight line and make an Acrobatics or Athletics check to jump as you do so.
+- Move 15 feet in a straight line and make an Acrobatics or Athletics check to [jump](#Exploration_Movement_jumping) as you do so.
   If a creature is within your reach when you land, you can make a melee weapon attack against it using the result of your check instead of an attack roll.
 - You can roll 1d4 in place of your normal damage for unarmed strikes.
   When rolling damage for your unarmed strikes, you can choose to deal bludgeoning, piercing, or slashing damage.

--- a/en-US/Players_Guide/03_Creating_a_Character/Feats/Feats/Surgical_Combatant.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Feats/Feats/Surgical_Combatant.md
@@ -4,5 +4,6 @@
   Until the start of your next turn, your weapon attacks score a critical hit on a roll of 19–20.
   \
   If you already have a feature that increases the range of your critical hits, your critical hit range increases by 1 (maximum 17–20).
-- You gain proficiency in Medicine. If you are already proficient, you instead gain expertise.
+- You gain proficiency in Medicine.
+  If you are already proficient, you instead gain expertise.
 - You gain expertise on Medicine checks made to diagnose the cause of, or treat, wounds.

--- a/en-US/Players_Guide/03_Creating_a_Character/Level_Advancement/Multiclassing.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Level_Advancement/Multiclassing.md
@@ -1,7 +1,8 @@
 #### Multiclassing
 
 Multiclassing lets you gain levels in multiple classes, mixing their abilities to create unique character concepts.
-You can gain a level in a new class whenever you advance, instead of your current class. Levels in all classes add up to determine your character level.
+You can gain a level in a new class whenever you advance, instead of your current class.
+Levels in all classes add up to determine your character level.
 For instance, three Wizard levels and two Fighter levels make you a 5th-level character.
 
 As you level up, you may stay in your original class with a few levels in another, or change course entirely.

--- a/en-US/Players_Guide/03_Creating_a_Character/Using_Ability_Scores/Ability_Checks.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Using_Ability_Scores/Ability_Checks.md
@@ -30,6 +30,7 @@ If the total equals or exceeds the DC, the ability check is a success—the crea
 Otherwise, it’s a failure, which means the character or monster makes no progress toward the objective or makes progress combined with a setback determined by the Conductor.
 
 ##### Contests
+
 When characters or monsters oppose each other, a contest determines the outcome.
 Both make ability checks for their efforts, applying bonuses and penalties.
 Instead of comparing totals to a DC, they compare their check totals.
@@ -37,16 +38,19 @@ The participant with the higher total wins.
 This character succeeds or prevents the other from succeeding.
 
 If the contest results in a tie, the situation remains unchanged.
-One contestant may win by default. For instance, if two characters tie in a contest to grab a ring, neither succeeds.
+One contestant may win by default.
+For instance, if two characters tie in a contest to grab a ring, neither succeeds.
 In a contest between a monster and an adventurer, a tie keeps the door shut.
 
 ##### Skills
+
 Each ability covers various capabilities, including proficiencies in skills.
 A skill represents a specific aspect of an ability score, and proficiency indicates focus on that aspect.
 Characters’ starting skill proficiencies are determined at creation, while monsters’ proficiencies appear in their stat blocks.
 
 For instance, a Dexterity check could reflect acrobatics, palming, or hiding.
-Each aspect has an associated skill: Acrobatics, Sleight of Hand, and Stealth. Proficiency in Stealth enhances Dexterity checks related to sneaking and hiding.
+Each aspect has an associated skill: Acrobatics, Sleight of Hand, and Stealth.
+Proficiency in Stealth enhances Dexterity checks related to sneaking and hiding.
 
 The skills typically related to each ability score are listed below.
 See an ability’s description for examples of skill usage.
@@ -99,6 +103,7 @@ In this case, you can apply Athletics proficiency and ask for a Constitution (At
 Similarly, when your dwarf Dreadnought uses raw strength to intimidate an enemy, your Conductor might ask for a Strength (Intimidation) check, despite Intimidation being usually associated with Charisma.
 
 ##### Passive Checks
+
 A passive check is a special kind of ability check that doesn’t involve any die rolls.
 Such a check can represent the average result for a task done repeatedly, such as searching for secret doors over and over again, or can be used when the Conductor wants to secretly determine whether the characters succeed at something without rolling dice, such as noticing a hidden monster (passive [Wisdom (Perception)](#Using_Wisdom_wisdom_checks)), noticing that someone is acting suspicious (passive [Wisdom (Insight)](#Using_Wisdom_wisdom_checks)), or noticing something out of place (passive [Intelligence (Investigation)](#Using_Intelligence_intelligence)).
 
@@ -109,7 +114,8 @@ Here’s how to determine a character’s total for a passive check:
 ```
 
 If the character has advantage on the check, add 5.
-For disadvantage, subtract 5. The game refers to a passive check total as a score.
+For disadvantage, subtract 5.
+The game refers to a passive check total as a score.
 
 For example, if a 1st-level character has a Wisdom of 15 and proficiency in Perception, they have a passive Wisdom (Perception) score of 14.
 

--- a/en-US/Players_Guide/03_Creating_a_Character/Using_Ability_Scores/Using_Constitution.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Using_Ability_Scores/Using_Constitution.md
@@ -22,4 +22,5 @@ Typically, you add your Constitution modifier to each Hit Die you roll for your 
 
 If your Constitution modifier changes, your hit point maximum changes as well, as though you had the new modifier from 1st level.
 For example, if you raise your Constitution score when you reach 4th level and your Constitution modifier increases from +1 to +2, you adjust your hit point maximum as though the modifier had always been +2.
-So you add 3 hit points for your first three levels, and then roll your hit points for 4th level using your new modifier. Or if you’re 7th level and some effect lowers your Constitution score so as to reduce your Constitution modifier by 1, your hit point maximum is reduced by 7.
+So you add 3 hit points for your first three levels, and then roll your hit points for 4th level using your new modifier.
+Or if you’re 7th level and some effect lowers your Constitution score so as to reduce your Constitution modifier by 1, your hit point maximum is reduced by 7.

--- a/en-US/Players_Guide/03_Creating_a_Character/Using_Ability_Scores/Using_Strength.md
+++ b/en-US/Players_Guide/03_Creating_a_Character/Using_Ability_Scores/Using_Strength.md
@@ -8,7 +8,7 @@ A Strength check can model any attempt to lift, push, pull, or break something, 
 The Athletics skill reflects aptitude in certain kinds of Strength checks.
 
 **Athletics.**
-Your Strength (Athletics) check covers difficult situations you encounter while climbing, jumping, or swimming.
+Your Strength (Athletics) check covers difficult situations you encounter while [climbing](#Exploration_Movement_climbing_swimming_and_crawling), [jumping](#Exploration_Movement_jumping), or [swimming](#Exploration_Movement_climbing_swimming_and_crawling).
 Examples include the following activities:
 
 - You attempt to climb a sheer or slippery cliff, avoid hazards while scaling a wall, or cling to a surface while something is trying to knock you off.

--- a/en-US/Players_Guide/04_Adventuring/Combat_Actions.md
+++ b/en-US/Players_Guide/04_Adventuring/Combat_Actions.md
@@ -9,7 +9,8 @@ When you describe an action not detailed elsewhere in the rules, the Conductor t
 
 The most common action to take in combat is the Attack action, whether you are swinging a sword, firing an arrow from a bow, or brawling with your fists.
 
-With this action, you make one melee or ranged attack. See the ["Making an Attack"](#Combat_Making_an_Attack_making_an_attack) section for the rules that govern attacks.
+With this action, you make one melee or ranged attack.
+See the ["Making an Attack"](#Combat_Making_an_Attack_making_an_attack) section for the rules that govern attacks.
 
 Certain features, such as the _Extra Attack_ feature of the Fighter, allow you to make more than one attack with this action.
 

--- a/en-US/Players_Guide/04_Adventuring/Combat_Making_an_Attack.md
+++ b/en-US/Players_Guide/04_Adventuring/Combat_Making_an_Attack.md
@@ -58,7 +58,8 @@ If you are hidden, not sensed at all, you reveal your location when you make an 
 ##### Ranged Attacks
 
 When you make a ranged attack, you fire a bow or a crossbow, hurl a handaxe, or otherwise send projectiles to strike a foe at a distance.
-A monster might shoot spines from its tail. Many spells also involve making a ranged attack.
+A monster might shoot spines from its tail.
+Many spells also involve making a ranged attack.
 
 ###### Range
 

--- a/en-US/Players_Guide/04_Adventuring/Combat_Movement_and_Position.md
+++ b/en-US/Players_Guide/04_Adventuring/Combat_Movement_and_Position.md
@@ -2,7 +2,8 @@
 
 In combat, characters and monsters are in constant motion, often using movement and position to gain the upper hand.
 
-On your turn, you can move a distance up to your speed. You can use as much or as little of your speed as you like on your turn, following the rules here.
+On your turn, you can move a distance up to your speed.
+You can use as much or as little of your speed as you like on your turn, following the rules here.
 
 Your movement can include jumping, climbing, and swimming.
 These different modes of movement can be combined with walking, or they can constitute your entire move.

--- a/en-US/Players_Guide/04_Adventuring/Combat_Movement_and_Position.md
+++ b/en-US/Players_Guide/04_Adventuring/Combat_Movement_and_Position.md
@@ -5,7 +5,7 @@ In combat, characters and monsters are in constant motion, often using movement 
 On your turn, you can move a distance up to your speed.
 You can use as much or as little of your speed as you like on your turn, following the rules here.
 
-Your movement can include jumping, climbing, and swimming.
+Your movement can include [jumping](#Exploration_Movement_jumping), [climbing](#Exploration_Movement_climbing_swimming_and_crawling), and [swimming](#Exploration_Movement_climbing_swimming_and_crawling).
 These different modes of movement can be combined with walking, or they can constitute your entire move.
 However you’re moving, you deduct the distance of each part of your move from your speed until it is used up or until you are done moving.
 

--- a/en-US/Players_Guide/04_Adventuring/Exploration.md
+++ b/en-US/Players_Guide/04_Adventuring/Exploration.md
@@ -1,6 +1,7 @@
 ### Exploration
 
-Exploration is more than just travel; it’s the thrill of the unknown. Adventurers face environmental challenges, solve mysteries, and adapt to changing landscapes.
+Exploration is more than just travel; it’s the thrill of the unknown.
+Adventurers face environmental challenges, solve mysteries, and adapt to changing landscapes.
 
 [**Time**](./Exploration_Time.md)
 

--- a/en-US/Players_Guide/04_Adventuring/Exploration_Environment.md
+++ b/en-US/Players_Guide/04_Adventuring/Exploration_Environment.md
@@ -63,7 +63,8 @@ Even gloomy days provide bright light, as do torches, lanterns, fires, and other
 
 **Dim light**, also called shadows, creates a lightly obscured area.
 An area of dim light is usually a boundary between a source of bright light, such as a torch, and surrounding darkness.
-The soft light of twilight and dawn also counts as dim light. A particularly brilliant full moon might bathe the land in dim light.
+The soft light of twilight and dawn also counts as dim light.
+A particularly brilliant full moon might bathe the land in dim light.
 
 **Darkness** creates a heavily obscured area.
 Characters face darkness outdoors at night (even most moonlit nights), within the confines of an unlit dungeon or a subterranean vault, or in an area of magical darkness.
@@ -76,7 +77,9 @@ However, the creature can’t discern color in darkness, only shades of gray.
 
 ##### Parasense
 
-A creature with parasense can pinpoint and observe its surroundings within a defined area (e.g., 60 ft. cone) without using sight. This sense relies on a supporting sense such as echolocation or sensitivity to air pressure, heat, electrical fields, or magical cues and may be disrupted by effects that interfere with that sense (e.g., Silence for echolocation, strong wind for air pressure). Parasense reveals position and general features but not fine detail.
+A creature with parasense can pinpoint and observe its surroundings within a defined area (e.g., 60 ft. cone) without using sight.
+This sense relies on a supporting sense such as echolocation or sensitivity to air pressure, heat, electrical fields, or magical cues and may be disrupted by effects that interfere with that sense (e.g., Silence for echolocation, strong wind for air pressure).
+Parasense reveals position and general features but not fine detail.
 
 ##### Truesight
 

--- a/en-US/Players_Guide/05_Planes_of_Existence/Planes_of_Existence.md
+++ b/en-US/Players_Guide/05_Planes_of_Existence/Planes_of_Existence.md
@@ -1,6 +1,7 @@
 ## Planes of Existence
 
-The multiverse consists of many interconnected planes, each with its own nature. Most adventures take place on a **Material Plane**, one of many that can host different campaign settings.
+The multiverse consists of many interconnected planes, each with its own nature.
+Most adventures take place on a **Material Plane**, one of many that can host different campaign settings.
 
 Every creature and object has a **plane of origin**.
 Surrounding the Material Plane are the **Inner Planes**, where elemental forces — air, earth, fire, water, and their interactions — exist in raw form.

--- a/en-US/Players_Guide/06_Spellcasting/Spellcasting.md
+++ b/en-US/Players_Guide/06_Spellcasting/Spellcasting.md
@@ -150,7 +150,8 @@ Some spells require concentration to maintain their magic.
 If you lose concentration, the spell ends.
 If a spell needs concentration, its Duration entry specifies how long you can concentrate.
 You can end concentration anytime.
-Normal activity doesn’t interfere. The following can break concentration:
+Normal activity doesn’t interfere.
+The following can break concentration:
 
 - **Casting another spell that requires concentration.**
   You lose concentration on a spell if you cast another spell that requires concentration.
@@ -183,7 +184,8 @@ If you’re in the spell’s area of effect, you can target yourself.
 #### Areas of Effect
 
 Spells like Burning Hands and Cone of Cold cover an area, affecting multiple creatures.
-The spell’s description specifies its area of effect, which can be a cone, cube, cylinder, line, or sphere. Each shape has a point of origin, from which the spell’s energy erupts.
+The spell’s description specifies its area of effect, which can be a cone, cube, cylinder, line, or sphere.
+Each shape has a point of origin, from which the spell’s energy erupts.
 The rules specify how to position the point of origin.
 It’s usually a point in space, but some spells have a creature or object as the origin.
 The effect expands in straight lines from the origin.


### PR DESCRIPTION
I tried to incorporate the changes on removing "Beginning at Xth level" or similar for features that only grant stuff at one level.

In addition to adding the Fighter, I also cleaned up some stuff. Specifically:
- I added more line breaks that won't show up in the rendered version, but will make reviewing changes here easier.
- I added more document internal links (e.g. we now always link to the jump rules when jumping is mentioned).