### PR TITLE
Update Vicious_Mockery.md

### DIFF
--- a/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/V/Vicious_Mockery.md
+++ b/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/V/Vicious_Mockery.md
@@ -9,6 +9,6 @@ _Enchantment cantrip_
 **Duration:** Instantaneous
 
 You verbally insult or mock one creature so viciously its mind is seared.
-As long as the target hears you (understanding your words is not required) it takes `1d6` psychic damage and has disadvantage on the first attack roll it makes before the end of its next turn if it fails a Wisdom saving throw.
+If the target can hear you (though it need not understand you), it must succeed on a Wisdom saving throw or take `1d4` psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn.
 
 The spell’s damage increases by 1d6 when you reach 5th level (`2d6`), 11th level (`3d6`), and 17th level (`4d6`).


### PR DESCRIPTION
If the target can hear you (though it need not understand you), it must succeed on a Wisdom saving throw or take `1d4` psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn.