### PR TITLE
Update Sunburst.md

### DIFF
--- a/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/S/Sunburst.md
+++ b/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/S/Sunburst.md
@@ -9,8 +9,8 @@ _8th-level evocation_
 **Duration:** Instantaneous
 
 Oozes and undead have disadvantage on saving throws made to resist this spell.
-You create a burst of radiant sunlight that fills the area. Each creature in the area takes 12d6 radiant damage and is blinded for 1 minute if it fails a Constitution saving throw.
-On a successful save, it takes half as much damage and isn't blinded by this spell.
+You create a burst of radiant sunlight that fills the area.
+Each creature in the area takes `12d6` radiant damage and is blinded for 1 minute if it fails a Constitution saving throw.On a successful save, it takes half as much damage and isn't blinded by this spell.
 A creature blinded by this spell repeats its saving throw at the end of each of its turns, ending the blindness on a successful save.
 
 This spell dispels any magical darkness in its area. This light is sunlight.


### PR DESCRIPTION
You create a burst of radiant sunlight that fills the area.
Each creature in the area takes `12d6` radiant damage and is blinded for 1 minute if it fails a Constitution saving throw.