### PR TITLE
Add a job that extracts the spell metadata to a TSV file

### DIFF
--- a/.github/workflows/convert-files-en-US.yml
+++ b/.github/workflows/convert-files-en-US.yml
@@ -17,6 +17,7 @@ jobs:
       date_format: '%m/%d/%Y'
       book_directory: 'en-US/Characters_Codex'
       book_main_file: 'Characters_Codex'
+      spell_descriptions_path: en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/
 
   convert-conductors-companion-en-us:
     name: Convert the en-US Conductor's Companion

--- a/.github/workflows/convert-files.yml
+++ b/.github/workflows/convert-files.yml
@@ -29,14 +29,18 @@ on:
         type: string
         required: false
         default: "artifacts"
+      spell_descriptions_path:
+        description: The directory holding spell descriptions
+        type: string
+        required: false
     outputs:
       workflow_started_timestamp:
         description: The timestamp at which the workflow was started
         value: ${{ jobs.convert-markdown-to-asciidoc.outputs.timestamp }}
 
 jobs:
-  convert-markdown-to-asciidoc:
-    name: ${{ inputs.language }}/${{ inputs.book_main_file }} Markdown -> AsciiDoc
+  create-timestamp:
+    name: ${{ inputs.language }}/${{ inputs.book_main_file }} Create timestamp
     runs-on: ubuntu-latest
     outputs:
       timestamp: ${{ steps.build-started-at.outputs.timestamp }}
@@ -44,6 +48,32 @@ jobs:
       - name: Store build started at timestamp
         id: build-started-at
         run: echo "timestamp=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_OUTPUT
+
+  extract-spells:
+    name: ${{ inputs.language }}/${{ inputs.book_main_file }} Extract spells
+    runs-on: ubuntu-latest
+    needs: create-timestamp
+    if: ${{ inputs.spell_descriptions_path  != '' }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Ensure that the output directory exists
+        run: mkdir -p "${{ inputs.generated_files_target_directory }}"
+      - name: Run the extraction tool
+        run: python3 tools/spell_extractor/spell_extractor.py "${{ inputs.spell_descriptions_path }}" "${{ inputs.generated_files_target_directory }}/spells-${{ inputs.language }}.tsv"
+      - name: Upload built Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: spells-${{ inputs.language }}-${{ needs.create-timestamp.outputs.timestamp }}.tsv
+          path: ${{ github.workspace }}/generated
+
+  convert-markdown-to-asciidoc:
+    name: ${{ inputs.language }}/${{ inputs.book_main_file }} Markdown -> AsciiDoc
+    runs-on: ubuntu-latest
+    needs: create-timestamp
+    outputs:
+      timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
+    steps:
       - name: Check out repository code
         uses: actions/checkout@v4
       - run: echo "📥 The ${{ github.repository }} repository has been cloned to the runner."
@@ -60,7 +90,7 @@ jobs:
       - name: Upload built Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.book_main_file }}-${{ inputs.language }}-adoc-${{ steps.build-started-at.outputs.timestamp }}
+          name: ${{ inputs.book_main_file }}-${{ inputs.language }}-adoc-${{ needs.create-timestamp.outputs.timestamp }}
           path: ${{ github.workspace }}/generated
       - run: echo "🐉 This job's status is ${{ job.status }}."
 

--- a/tools/spell_extractor/spell_extractor.py
+++ b/tools/spell_extractor/spell_extractor.py
@@ -26,7 +26,7 @@ for root, dirs, files in os.walk(spellpath):
       spelldict['spell_name'] = spellname
 
       for line in lines:
-        match = re.search('^\[_metadata_:([\w_\.]+)\]:-\s*"([^"]*)"', line)
+        match = re.search('^\\[_metadata_:([\\w_\\.]+)\\]:-\\s*"([^"]*)"', line)
         if match:
           print('  {:35s} -> {}'.format(match.group(1), match.group(2)))
           spelldict[match.group(1)] = match.group(2)


### PR DESCRIPTION
An example for a successful run can be seen at https://github.com/wyrmworkspublishing/free5e/actions/runs/16948691554?pr=240 - right at the bottom of the artifacts there's a file called `spells-en-US-2025-08-13T20-36-14.tsv.zip` that contains the spells TSV produced by the new job.