### PR TITLE
Replace True Strike with a cantrip actually worth having

### DIFF
--- a/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/T/True_Strike.md
+++ b/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/T/True_Strike.md
@@ -1,12 +1,28 @@
 #### True Strike
-<!-- TODO Check and tag this spell-->
+<!-- markdownlint-disable link-image-reference-definitions -->
+[_metadata_:spell_name]:- "True Strike"
+[_metadata_:spell_level]:- "0"
+[_metadata_:spell_school]:- "divination"
+[_metadata_:ritual]:- "false"
+[_metadata_:casting_time_amount]:- "1"
+[_metadata_:casting_time_unit]:- "action"
+[_metadata_:range]:- "Self"
+[_metadata_:target]:- "Self"
+[_metadata_:components_verbal]:- "false"
+[_metadata_:components_somatic]:- "true"
+[_metadata_:components_material]:- "false"
+[_metadata_:duration]:- "1 round"
+[_metadata_:concentration]:- "true"
+[_metadata_:compared_to_wotc_srd_5.1]:- "mechanics_different_wording_different"
+[_metadata_:compared_to_a5e_srd]:- "mechanics_different_wording_different"
 <!-- markdownlint-disable-next-line no-emphasis-as-heading -->
 _Divination cantrip_
 
 **Casting Time:** 1 action \
-**Range:** 30 feet \
+**Range:** Self \
 **Components:** S \
 **Duration:** Concentration, up to 1 round
 
-You gain an innate understanding of the defenses of a chosen creature or object in range.
-You have advantage on your first attack roll made against the target before the end of your next turn.
+Your foresight guides a perfect moment to strike.
+Until the end of your next turn, the first weapon attack you make ignores disadvantage and half or three-quarters cover.
+If that attack hits, roll the weapon’s damage dice twice and use the higher result.


### PR DESCRIPTION
So far it looks like the new version of _True Strike_ works. Let's add it; we can still change it at a later point, if we decide to do so.