### PR TITLE
Remove numbering of sections

### DIFF
--- a/.github/convert-files/conversion-scripts/markdown-to-asciidoc.sh
+++ b/.github/convert-files/conversion-scripts/markdown-to-asciidoc.sh
@@ -29,7 +29,7 @@ function convert_markdown_to_asciidoc {
       -a reproducible \
       -a revdate="$(LANG="${INPUT_LANGUAGE}" git log -1 --pretty="format:%cd" --date=format:"${INPUT_DATE_FORMAT}" .)" \
       -a sectnums \
-      -a sectnumelevels=1 \
+      -a sectnumlevels=1 \
       -a stem \
       -a table-stripes=even \
       -a toc \


### PR DESCRIPTION
This change makes sure that only parts and chapters are numbered, not sections. Examples of the results can be found in https://github.com/wyrmworkspublishing/free5e/actions/runs/17764870856?pr=289.