### PR TITLE
Include spell description in exported spells table

### DIFF
--- a/.github/workflows/convert-files.yml
+++ b/.github/workflows/convert-files.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Ensure that the output directory exists
         run: mkdir -p "${{ inputs.generated_files_target_directory }}"
       - name: Run the extraction tool
-        run: python3 tools/spell_extractor/spell_extractor.py "${{ inputs.spell_descriptions_path }}" "${{ inputs.generated_files_target_directory }}/spells-${{ inputs.language }}.tsv"
+        run: python3 tools/spell_extractor/spell_extractor.py "${{ inputs.language }}" "${{ inputs.spell_descriptions_path }}" "${{ inputs.generated_files_target_directory }}/spells-${{ inputs.language }}.tsv"
       - name: Upload built Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/A/Acid_Splash.md
+++ b/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/A/Acid_Splash.md
@@ -29,4 +29,4 @@ _Conjuration cantrip_
 
 A stinking bubble of acid is conjured out of thin air to fly at up to two creatures within 5 feet of each other, dealing `1d6` acid damage, half damage on a successful Dexterity saving throw.
 
-This spell’s damage increases by 1d6 when you reach 5th level (`2d6`), 11th level (`3d6`), and 17th level (`4d6`).
+This spell’s damage increases by `1d6` when you reach 5th level (`2d6`), 11th level (`3d6`), and 17th level (`4d6`).

--- a/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/A/Aid.md
+++ b/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/A/Aid.md
@@ -25,7 +25,7 @@ _2nd-level abjuration_
 **Duration:** 8 hours
 
 You draw upon divine power, imbuing up to three creatures with fortitude.
-Until the spell ends, each target increases its hit point maximum and current hit points by 5.
+Until the spell ends, each target increases its hit point maximum and current hit points by `5`.
 
 **At Higher Levels.**
-The granted hit points increase by an additional 5 for each slot level above 2nd.
+The granted hit points increase by an additional `5` for each slot level above 2nd.

--- a/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/F/Fire_Bolt.md
+++ b/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/F/Fire_Bolt.md
@@ -30,4 +30,4 @@ Make a ranged spell attack.
 On a hit, you deal `1d10` fire damage.
 An unattended flammable object is ignited.
 
-This spell’s damage increases by 1d10 when you reach 5th level (`2d10`), 11th level (`3d10`), and 17th level (`4d10`).
+This spell’s damage increases by `1d10` when you reach 5th level (`2d10`), 11th level (`3d10`), and 17th level (`4d10`).

--- a/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/S/Shocking_Grasp.md
+++ b/en-US/Characters_Codex/06_Spellcasting/Spell_Descriptions/S/Shocking_Grasp.md
@@ -29,4 +29,4 @@ Electricity arcs from your fingertips to shock one creature.
 Make a melee spell attack (with advantage if the target is wearing metal armor).
 On a hit, you deal `1d8` lightning damage, and the target can’t take reactions until the start of its next turn as the electricity courses through its body.
 
-This spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).
+This spell’s damage increases by `1d8` when you reach 5th level (`2d8`), 11th level (`3d8`), and 17th level (`4d8`).

--- a/tools/spell_extractor/spell_extractor.py
+++ b/tools/spell_extractor/spell_extractor.py
@@ -8,7 +8,8 @@ language = sys.argv[1]
 spellpath = sys.argv[2]
 outfile = sys.argv[3]
 
-with open("spell_extractor.toml", "rb") as f:
+dir_path = os.path.dirname(os.path.realpath(__file__))
+with open(dir_path + '/spell_extractor.toml', 'rb') as f:
     configData = tomllib.load(f)
 configForLang = configData.get(language)
 regexConfigs = configForLang['regexes']

--- a/tools/spell_extractor/spell_extractor.py
+++ b/tools/spell_extractor/spell_extractor.py
@@ -55,7 +55,7 @@ for root, dirs, files in os.walk(spellpath):
         matchAtHigherLevels = re.search(regexConfigs['atHigherLevelsRegex'], line)
         matchCantripDamageIncrease = re.search(regexConfigs['cantripDamageIncreaseRegex'], line)
         matchCantripBeamIncrease = re.search(regexConfigs['cantripBeamIncreaseRegex'], line)
-        if (line_number < duration_line + 2):
+        if (line_number < duration_line + 2 or (at_higher_levels_start_line != None and line_number >= at_higher_levels_start_line)):
           continue
         elif matchAtHigherLevels:
           # We don't need the "At higher levels" part to be included
@@ -63,7 +63,8 @@ for root, dirs, files in os.walk(spellpath):
           continue
         elif matchCantripDamageIncrease or matchCantripBeamIncrease:
           at_higher_levels_start_line = line_number
-        elif at_higher_levels_start_line == None:
+          continue
+        else:
           spell_text = line.replace('\n', '\\n')
           spell_text_list.append(spell_text)
       spelldict['spell_text'] = ''.join(spell_text_list).removesuffix('\\n').removesuffix('\\n')
@@ -78,6 +79,7 @@ for root, dirs, files in os.walk(spellpath):
             at_higher_levels_text = line.replace('\n', '\\n')
             at_higher_levels_list.append(at_higher_levels_text)
         spelldict['spell_at_higher_levels'] = ''.join(at_higher_levels_list).removesuffix('\\n')
+        print('  spell_at_higher_levels            -> {}'.format(spelldict['spell_at_higher_levels']))
 
       if len(spelldict) > 1:
         spells.append(spelldict)

--- a/tools/spell_extractor/spell_extractor.toml
+++ b/tools/spell_extractor/spell_extractor.toml
@@ -1,0 +1,22 @@
+# This is the configuration file for the spell extractor
+
+[en-US.regexes]
+metadataRegex = "^\\[_metadata_:([\\w_\\.]+)\\]:-\\s*\"([^\"]*)\""
+durationRegex = "^\\*\\*Duration:\\*\\* .*"
+atHigherLevelsRegex = "^\\*\\*At Higher Levels.\\*\\*.*"
+cantripDamageIncreaseRegex = "^This spell’s damage increases.*"
+cantripBeamIncreaseRegex = "^The spell creates more than one beam when you reach higher levels:.*"
+
+[es-MX.regexes]
+metadataRegex = "^\\[_metadata_:([\\w_\\.]+)\\]:-\\s*\"([^\"]*)\""
+durationRegex = "^\\*\\*Duración:\\*\\* .*"
+atHigherLevelsRegex = "^\\*\\*A niveles superiores.\\*\\*.*"
+cantripDamageIncreaseRegex = "^El daño del conjuro aumenta en.*"
+cantripBeamIncreaseRegex = "^El conjuro crea más de un rayo cuando alcanzas niveles superiores:.*"
+
+[de-DE.regexes]
+metadataRegex = "^\\[_metadata_:([\\w_\\.]+)\\]:-\\s*\"([^\"]*)\""
+durationRegex = "^\\*\\*Wirkungsdauer:\\*\\* .*"
+atHigherLevelsRegex = "^\\*\\*Auf höheren Graden:\\*\\*.*"
+cantripDamageIncreaseRegex = "^Der Schaden dieses Zaubers wird jeweils um.*"
+cantripBeamIncreaseRegex = "^Auf höheren Stufen erschafft der Zauber mehr als einen Strahl:.*"

--- a/tools/spell_tagger/spell_tagger.py
+++ b/tools/spell_tagger/spell_tagger.py
@@ -1,6 +1,7 @@
 # This tool will extract certain tags from a spell file.
 # It does NOT however claim to extract anything from the actual spell text; so things such as damage dice or types, saving throws, etc. have to be added manually.
 # It can also not determine, where this spell comes from or whether it was renamed.
+import os
 import re
 import sys
 import tomllib
@@ -13,7 +14,8 @@ languageMatch = re.match('^[a-z]{2}-[A-Z]{2}$', language)
 if (not languageMatch):
   raise Exception('Invalid language "{}"'.format(language))
 
-with open("spell_tagger.toml", "rb") as f:
+dir_path = os.path.dirname(os.path.realpath(__file__))
+with open(dir_path + '/spell_tagger.toml', 'rb') as f:
     configData = tomllib.load(f)
 configForLang = configData.get(language)
 


### PR DESCRIPTION
This change adds the spell description as well as any upcast or cantrip level-up effects to the exported spells TSV files. This should make building automations (e.g. automated character sheets and spell card generators) easier.