### PR TITLE
Add some sections of the 'Building a TTRPG Group' chapter

### DIFF
--- a/en-US/Conductors_Companion/02_Starting_a_Campaign/Bulding_a_TTRPG_Group/Building_a_TTRPG_Group.md
+++ b/en-US/Conductors_Companion/02_Starting_a_Campaign/Bulding_a_TTRPG_Group/Building_a_TTRPG_Group.md
@@ -1,5 +1,8 @@
 ## Building a TTRPG Group
 
+> **Warning**
+> This section has not yet been written.
+
 [Finding and Maintaining a Solid Group](./Finding_and_Maintaining_a_Solid_Group.md)
 
 [Choose a Regular Schedule](./Choose_a_Regular_Schedule.md)

--- a/en-US/Conductors_Companion/02_Starting_a_Campaign/Bulding_a_TTRPG_Group/Finding_Players.md
+++ b/en-US/Conductors_Companion/02_Starting_a_Campaign/Bulding_a_TTRPG_Group/Finding_Players.md
@@ -1,4 +1,10 @@
 #### Finding Players
 
-> **Warning**
-> This section has not yet been transferred from the Google Doc.
+The first step to building an RPG group is finding players.
+Some of the most common ways to find players for a group include the following:
+
+- Recruit friends and family
+- Recruit people you know from work, school, faith communities, or other social groups
+- Ask about putting a notice up at your local game store or library
+- Join local organized play groups
+- Seek LFG (Looking for Group) forums on social media and other forums

--- a/en-US/Conductors_Companion/02_Starting_a_Campaign/Bulding_a_TTRPG_Group/Finding_and_Maintaining_a_Solid_Group.md
+++ b/en-US/Conductors_Companion/02_Starting_a_Campaign/Bulding_a_TTRPG_Group/Finding_and_Maintaining_a_Solid_Group.md
@@ -1,7 +1,7 @@
 ### Finding and Maintaining a Solid Group
 
-> **Warning**
-> This section has not yet been transferred from the Google Doc.
+Finding and maintaining a solid group for roleplaying gaming remains the most difficult task for many Conductors.
+This section offers suggestions for finding players that fit well with your group, and for keeping that group going for years to come.
 
 [Finding Players](./Finding_Players.md)
 


### PR DESCRIPTION
Reading some of the subsections here made it once again very clear that the author assumes a very specific play style. I've left comments in the Google Doc and have in this PR only transferred the subsections that don't depend on that.

Also, the section on selecting players is about adding experienced players to an existing group. Many Conductors, who will be reading this, will be looking to start a new group and trying to assess who should be part of that group. We currently have _nothing_ for them beyond the very general _Finding Players_ chapter (which doesn't talk about the selection process).