### PR TITLE
Move some document specific data to the documents

### DIFF
--- a/.github/convert-files/conversion-scripts/markdown-to-asciidoc.sh
+++ b/.github/convert-files/conversion-scripts/markdown-to-asciidoc.sh
@@ -10,8 +10,6 @@ CONVERSION_SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/nul
 function convert_markdown_to_asciidoc {
   echo "Converting Markdown files from $(pwd) to AsciiDoc..."
 
-  lang="$(cut -d '-' -f1 <<< "$INPUT_LANGUAGE")"
-
   for md in $(find . -name '*.md'); do
     md_filepath="$(dirname -- $md)"
     md_filename="${md##*/}"
@@ -22,11 +20,7 @@ function convert_markdown_to_asciidoc {
     # Convert all the Markdown files to AsciiDoc
     echo "Converting ${md} to ${adoc_filepath}/${adoc_filename}..."
     kramdoc \
-      -a author="Wyrmworks Publishing"  \
-      -a copyright="Creative Commons Attribution 4.0 International License (CC-BY-4.0)" \
-      -a doctype=book \
       -a icons=font \
-      -a lang="${lang}" \
       -a partnums \
       -a reproducible \
       -a revdate="$(LANG="${INPUT_LANGUAGE}" git log -1 --pretty="format:%cd" --date=format:"${INPUT_DATE_FORMAT}" .)" \
@@ -34,8 +28,6 @@ function convert_markdown_to_asciidoc {
       -a sectnumlevels=1 \
       -a stem \
       -a table-stripes=even \
-      -a toc \
-      -a toclevels=2 \
       --auto-ids \
       --auto-id-prefix="${md_filename%.md}_" \
       --auto-id-separator="_" \

--- a/de-DE/Codex_der_Charaktere/Codex_der_Charaktere.md
+++ b/de-DE/Codex_der_Charaktere/Codex_der_Charaktere.md
@@ -1,3 +1,11 @@
+---
+author: Wyrmworks Publishing
+copyright: Creative Commons Namensnennung 4.0 International Lizenz (CC-BY-4.0)
+doctype: book
+lang: de
+toc: true
+toclevels: 2
+---
 # Codex der Charaktere: Das Free5e Handbuch für Spielende
 (<mark>Vorschau - Inhalt in Bearbeitung</mark>)
 

--- a/de-DE/dictionary.txt
+++ b/de-DE/dictionary.txt
@@ -28,6 +28,7 @@ Chloe*
 Coast
 Commons
 Compendium
+copyright
 Coreador*
 Creative
 Dimensionstür
@@ -93,6 +94,8 @@ Tabletop
 Tasty
 Teleportation
 Thaumaturgie
+toclevels
+true
 TTRPG
 Unverwundbarkeit
 Verzauberungs*

--- a/en-US/Characters_Codex/Characters_Codex.md
+++ b/en-US/Characters_Codex/Characters_Codex.md
@@ -1,3 +1,11 @@
+---
+author: Wyrmworks Publishing
+copyright: Creative Commons Attribution 4.0 International License (CC-BY-4.0)
+doctype: book
+lang: en
+toc: true
+toclevels: 2
+---
 # Free5e Character's Codex: Player’s Guide to Free5e
 
 Sign up to receive email updates at [https://wyrmworkspublishing.com/hoard](https://wyrmworkspublishing.com/hoard)

--- a/en-US/Conductors_Companion/03_Preparing_Quests_and_Adventures/Preparing_Quests_and_Adventures.md
+++ b/en-US/Conductors_Companion/03_Preparing_Quests_and_Adventures/Preparing_Quests_and_Adventures.md
@@ -8,5 +8,3 @@
 [Combat Encounter Building](./Combat_Encounter_Building/Combat_Encounter_Building.md)
 
 [Preparing Magic Items](./Magic_Items/Preparing_Magic_Items.md)
-
-[Random Generators](./Random_Generators/Random_Generators.md)

--- a/en-US/Conductors_Companion/04_Running_Game_Sessions/Combat_Encounters/Combat_Encounter_Building/Combat_Encounter_Building.md
+++ b/en-US/Conductors_Companion/04_Running_Game_Sessions/Combat_Encounters/Combat_Encounter_Building/Combat_Encounter_Building.md
@@ -1,4 +1,0 @@
-### Combat Encounter Building
-
-> **Warning**
-> This section has not yet been transferred from the Google Doc.

--- a/en-US/Conductors_Companion/04_Running_Game_Sessions/Combat_Encounters/Combat_Encounters.md
+++ b/en-US/Conductors_Companion/04_Running_Game_Sessions/Combat_Encounters/Combat_Encounters.md
@@ -1,7 +1,5 @@
 ## Combat Encounters
 
-[Combat Encounter Building](./Combat_Encounter_Building/Combat_Encounter_Building.md)
-
 [Quick Tricks for Combat Encounters](./Quick_Tricks/Quick_Tricks.md)
 
 [Theater of the Mind Guidelines](./Theater_of_the_Mind/Theater_of_the_Mind.md)

--- a/en-US/Conductors_Companion/Conductors_Companion.md
+++ b/en-US/Conductors_Companion/Conductors_Companion.md
@@ -1,3 +1,11 @@
+---
+author: Wyrmworks Publishing
+copyright: Creative Commons Attribution 4.0 International License (CC-BY-4.0)
+doctype: book
+lang: en
+toc: true
+toclevels: 2
+---
 # Free5e Conductor's Companion: Tips, Tools, and Advice for Running Free5e
 
 (<mark>Preview Work-in-Progress</mark>)

--- a/en-US/Migration_Guide/5e_Migration_Guide.md
+++ b/en-US/Migration_Guide/5e_Migration_Guide.md
@@ -1,3 +1,10 @@
+---
+copyright: Creative Commons Attribution 4.0 International License (CC-BY-4.0)
+doctype: article
+lang: en
+toc: true
+toclevels: 2
+---
 # 5e 2014 to Free5e Migration Guide
 
 > **Warning**

--- a/en-US/Monstrous_Manuscript/Monstrous_Manuscript.md
+++ b/en-US/Monstrous_Manuscript/Monstrous_Manuscript.md
@@ -1,3 +1,11 @@
+---
+author: Wyrmworks Publishing
+copyright: Creative Commons Attribution 4.0 International License (CC-BY-4.0)
+doctype: book
+lang: en
+toc: true
+toclevels: 2
+---
 # Free5e Monstrous Manuscript: Hundreds of Monsters and Creatures for Free5e
 
 (<mark>Preview Work-in-Progress</mark>)

--- a/en-US/dictionary.txt
+++ b/en-US/dictionary.txt
@@ -150,6 +150,7 @@ tiefling*
 themself
 Theurge
 Thunderwave
+toclevels
 treeborne
 tremorsense
 truesight

--- a/es-MX/Pergamino_de_Personajes/Pergamino_de_Personajes.md
+++ b/es-MX/Pergamino_de_Personajes/Pergamino_de_Personajes.md
@@ -1,3 +1,11 @@
+---
+author: Wyrmworks Publishing
+copyright: licencia Creative Commons 4.0 Atribución/Reconocimiento (CC-BY-4.0)
+doctype: book
+lang: es
+toc: true
+toclevels: 2
+---
 # Free5e Pergamino de Personajes
 (<mark>Anticipo de trabajo en elaboración</mark>)
 

--- a/es-MX/dictionary.txt
+++ b/es-MX/dictionary.txt
@@ -34,6 +34,7 @@ Sequoia
 Sanchini
 Shea
 Tasty
+toclevels
 Wizards
 WotC
 Wyrmworks


### PR DESCRIPTION
This makes the build process both simpler and more flexible.
What we're using here is _Markdown frontmatter_, a rarely used but useful feature of Markdown.